### PR TITLE
Enable select2 for list/enumeration custom fields

### DIFF
--- a/assets/javascripts/searchable_selectbox.js
+++ b/assets/javascripts/searchable_selectbox.js
@@ -90,6 +90,14 @@ function replaceSelect2() {
     if (excludedSelect.length) {
       excludedSelect.select2('destroy');
     }
+
+    /* Enable select2 for list and enumerations Custom Fields formats */
+    const customFields = $('select.enumeration_cf, select.list_cf');
+    if (customFields.length) {
+      customFields.select2().on('select2:select', function() {
+        retriggerChangeIfNativeEventExists($(this));
+      });
+    }
   }
 }
 


### PR DESCRIPTION
As far I understand selector `select:not([multiple])` is used to exclude query filters that are broken when replaced with select2.
But there are custom fields that may have a `Multiple values` flag and those fields also ignored.

I've tried to enable select2 for list/enumaretion custom fields, it works fine.

An example using default test fixtures. Database's `Multiple values` set to true:

![Peek 2022-10-11 11-08](https://user-images.githubusercontent.com/49897128/195039637-9e26ffed-0b75-45d0-8aed-28dfd8012b80.gif)

